### PR TITLE
Fixed typo in exception handling

### DIFF
--- a/cheroot/server.py
+++ b/cheroot/server.py
@@ -810,7 +810,7 @@ class HTTPRequest(object):
             self.conn.wfile.write(EMPTY.join(buf))
         except socket.error:
             x = sys.exc_info()[1]
-            if x.args[0] not in errors.esocket_errors_to_ignore:
+            if x.args[0] not in errors.socket_errors_to_ignore:
                 raise
 
     def write(self, chunk):


### PR DESCRIPTION
Fix for
``` 
File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/home/user/env/python2/local/lib/python2.7/site-packages/cheroot/workers/threadpool.py", line 103, in run
    conn.communicate()
  File "/home/user/env/python2/local/lib/python2.7/site-packages/cheroot/server.py", line 978, in communicate
    req.simple_response('408 Request Timeout')
  File "/home/user/env/python2/local/lib/python2.7/site-packages/cheroot/server.py", line 827, in simple_response
    if x.args[0] not in errors.esocket_errors_to_ignore:
AttributeError: 'module' object has no attribute 'esocket_errors_to_ignore'
```